### PR TITLE
Get build working on 8.8,8.10, CPP semigroup imports

### DIFF
--- a/unpacked-containers/src/Map/Internal.hs
+++ b/unpacked-containers/src/Map/Internal.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE Trustworthy #-}
 {-# LANGUAGE RoleAnnotations #-}
@@ -328,7 +329,11 @@ import Data.Coerce
 import Data.Data
 import Data.Functor.Classes
 import Data.Functor.Identity (Identity (..))
+#if __GLASGOW_HASKELL__ < 804
 import Data.Semigroup (Semigroup((<>), stimes), stimesIdempotentMonoid)
+#else
+import Data.Semigroup (Semigroup(stimes), stimesIdempotentMonoid)
+#endif
 import GHC.Exts (build, lazy, Proxy#, proxy# )
 import Prelude hiding (lookup, map, filter, foldr, foldl, null, splitAt, take, drop)
 import Text.Read hiding (lift)
@@ -3781,4 +3786,3 @@ splitRoot orig =
     Tip           -> []
     Bin _ k v l r -> [l, singleton k v, r]
 {-# INLINE splitRoot #-}
-

--- a/unpacked-containers/src/Set/Internal.hs
+++ b/unpacked-containers/src/Set/Internal.hs
@@ -1,4 +1,5 @@
 {-# language BangPatterns #-}
+{-# language CPP #-}
 {-# language PatternGuards #-}
 {-# language TypeFamilies #-}
 {-# language LambdaCase #-}
@@ -202,7 +203,11 @@ import Data.Bits (shiftL, shiftR)
 import Data.Data
 import Data.Default.Class
 import qualified Data.List as List
+#if __GLASGOW_HASKELL__ < 804
 import Data.Semigroup (Semigroup((<>), stimes), stimesIdempotentMonoid)
+#else
+import Data.Semigroup (Semigroup(stimes), stimesIdempotentMonoid)
+#endif
 import GHC.Exts (build, lazy, isTrue#, reallyUnsafePtrEquality#)
 import qualified GHC.Exts as GHCExts
 import Prelude hiding (filter,foldMap,foldl,foldr,null,map,take,drop,splitAt)

--- a/unpacked-containers/unpacked-containers.cabal
+++ b/unpacked-containers/unpacked-containers.cabal
@@ -1,9 +1,10 @@
+cabal-version: 2.0
+
 name:          unpacked-containers
 category:      Language
 version:       0
 license:       BSD2
 license-file:  LICENSE
-cabal-version: 2.0
 author:        Edward A. Kmett
 maintainer:    Edward A. Kmett <ekmett@gmail.com>
 stability:     experimental
@@ -69,7 +70,7 @@ library utils
     Internal.StrictMaybe
     Internal.PtrEquality
 
--- we have to provide a module in another library that matches the signature 
+-- we have to provide a module in another library that matches the signature
 library example
   default-language: Haskell2010
   hs-source-dirs: example

--- a/unpacked-unordered-containers/src/HashMap/Base.hs
+++ b/unpacked-unordered-containers/src/HashMap/Base.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE RoleAnnotations #-}
@@ -105,7 +106,9 @@ import Data.Hashable (Hashable)
 import qualified Data.Hashable as H
 import qualified Data.Hashable.Lifted as H
 import qualified Data.List as L
-import Data.Semigroup (Semigroup((<>)))
+#if __GLASGOW_HASKELL__ < 804
+import Data.Semigroup (Semigroup(..))
+#endif
 import GHC.Exts ((==#), build, reallyUnsafePtrEquality#, isTrue#)
 import qualified GHC.Exts as Exts
 import Prelude hiding (filter, foldr, lookup, map, null, pred)
@@ -1031,7 +1034,7 @@ filterWithKey pred = filterMapAux onLeaf onColl
 
 -- | Common implementation for 'filterWithKey' and 'mapMaybeWithKey',
 --   allowing the former to former to reuse terms.
-filterMapAux :: forall v1 v2. 
+filterMapAux :: forall v1 v2.
                 (HashMap v1 -> Maybe (HashMap v2))
              -> (Leaf v1 -> Maybe (Leaf v2))
              -> HashMap v1

--- a/unpacked-unordered-containers/src/HashSet.hs
+++ b/unpacked-unordered-containers/src/HashSet.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE Trustworthy #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -71,7 +72,9 @@ module HashSet
 import Control.DeepSeq (NFData(..))
 import Data.Data hiding (Typeable)
 import Data.Hashable (Hashable(hashWithSalt))
+#if __GLASGOW_HASKELL__ < 804
 import Data.Semigroup (Semigroup(..))
+#endif
 import GHC.Exts (build)
 import Prelude hiding (filter, foldr, map, null)
 import qualified Data.List as List

--- a/unpacked-unordered-containers/unpacked-unordered-containers.cabal
+++ b/unpacked-unordered-containers/unpacked-unordered-containers.cabal
@@ -1,9 +1,10 @@
+cabal-version: 2.0
+
 name:          unpacked-unordered-containers
 category:      Language
 version:       0
 license:       BSD2
 license-file:  LICENSE
-cabal-version: 2.0
 author:        Edward A. Kmett
 maintainer:    Edward A. Kmett <ekmett@gmail.com>
 stability:     experimental
@@ -39,7 +40,7 @@ library
     base >= 4.10 && < 5,
     data-default-class ^>= 0.1,
     deepseq ^>= 1.4,
-    hashable ^>= 1.2.7,
+    hashable >= 1.2.7 && <1.4,
     ghc-prim,
     utils
 


### PR DESCRIPTION
Gets the project building on GHC 8.8.* and 8.10.*. `hashable` needed a major version bump in `unpacked-unordered-containers`, and we had to CPP the semigroup imports. 